### PR TITLE
Update Travis CI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/swcraig/oxford-dictionary.svg?branch=master)](https://travis-ci.org/swcraig/oxford-dictionary)
+[![Build Status](https://travis-ci.org/swcraig/oxford_dictionary.svg?branch=master)](https://travis-ci.org/swcraig/oxford_dictionary)
 [![Test Coverage](https://codeclimate.com/github/swcraig/oxford-dictionary/badges/coverage.svg)](https://codeclimate.com/github/swcraig/oxford-dictionary/coverage)
 [![Code Climate](https://codeclimate.com/github/swcraig/oxford-dictionary/badges/gpa.svg)](https://codeclimate.com/github/swcraig/oxford-dictionary)
 [![Gem Version](https://badge.fury.io/rb/oxford_dictionary.svg)](https://badge.fury.io/rb/oxford_dictionary)


### PR DESCRIPTION
I renamed the repository to match the gem name so this was out of date.