### PR TITLE
Change main branch for the Action running tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,9 +2,9 @@ name: Run default rake task (tests) on PRs and main rebases
 
 on:
   push:
-    branches: [ main ]
+    branches: [ master ]
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 
 jobs:
   test:


### PR DESCRIPTION
When I made this action I thought that the repository was already using
the "main" branch nomenklature.

GitHub is suggesting that repositories wait until "later this year" to
make the branch name change. They are going to have tools to make this
seamless:
https://github.com/github/renaming